### PR TITLE
Refactor: EditManagers

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const client = axios.create({
   // 로컬 테스트시 주석
-  // baseURL: import.meta.env.VITE_SERVER_URL,
+  baseURL: import.meta.env.VITE_SERVER_URL,
   timeout: 600 * 1000,
   headers: {
     "Content-Type": "application/json",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const client = axios.create({
   // 로컬 테스트시 주석
-  baseURL: import.meta.env.VITE_SERVER_URL,
+  // baseURL: import.meta.env.VITE_SERVER_URL,
   timeout: 600 * 1000,
   headers: {
     "Content-Type": "application/json",

--- a/src/hooks/Admins.jsx
+++ b/src/hooks/Admins.jsx
@@ -1,0 +1,40 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { addManager, deleteManger, getManagerList } from "../api/Managers";
+
+const queriesToInvalidate = [
+  "managers",
+  "customMachines",
+  "customMachinesTemp",
+  "customFoods",
+  "customFoodsTemp",
+];
+
+export function useEditManagers() {
+  const queryClient = useQueryClient();
+  const managersQuery = useQuery(["managers"], () => getManagerList(), {
+    staleTime: Infinity,
+    cacheTime: Infinity,
+  });
+
+  const invalidateManagerQueries = () => {
+    queriesToInvalidate.forEach((query) =>
+      queryClient.invalidateQueries([query])
+    );
+  };
+
+  const addMgr = useMutation(
+    ({ manager }) => addManager([{ mgrname: manager }]),
+    {
+      onSuccess: invalidateManagerQueries,
+    }
+  );
+
+  const delMgr = useMutation(
+    ({ id, manager }) => deleteManger([{ id, mgrname: manager }]),
+    {
+      onSuccess: invalidateManagerQueries,
+    }
+  );
+
+  return { managersQuery, addMgr, delMgr };
+}

--- a/src/hooks/useManagers.jsx
+++ b/src/hooks/useManagers.jsx
@@ -8,6 +8,14 @@ import {
   submitAccounts,
 } from "../api/Managers";
 
+const queriesToInvalidate = [
+  "managers",
+  "customMachines",
+  "customMachinesTemp",
+  "customFoods",
+  "customFoodsTemp",
+];
+
 export function useManagers() {
   const queryClient = useQueryClient();
   const [manager, setManager] = useState("");
@@ -16,25 +24,23 @@ export function useManagers() {
     cacheTime: Infinity,
   });
 
+  const invalidateManagerQueries = () => {
+    queriesToInvalidate.forEach((query) =>
+      queryClient.invalidateQueries([query])
+    );
+  };
+
   const addMgr = useMutation(
     ({ manager }) => addManager([{ mgrname: manager }]),
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries(["managers"]);
-        queryClient.invalidateQueries(["customMachines"]);
-        queryClient.invalidateQueries(["customFoods"]);
-      },
+      onSuccess: () => invalidateManagerQueries,
     }
   );
 
   const delMgr = useMutation(
     ({ id, manager }) => deleteManger([{ id, mgrname: manager }]),
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries(["managers"]);
-        queryClient.invalidateQueries(["customMachines"]);
-        queryClient.invalidateQueries(["customFoods"]);
-      },
+      onSuccess: () => invalidateManagerQueries,
     }
   );
 

--- a/src/hooks/useManagers.jsx
+++ b/src/hooks/useManagers.jsx
@@ -18,7 +18,6 @@ const queriesToInvalidate = [
 
 export function useManagers() {
   const queryClient = useQueryClient();
-  const [manager, setManager] = useState("");
   const managersQuery = useQuery(["managers"], () => getManagerList(), {
     staleTime: Infinity,
     cacheTime: Infinity,
@@ -33,32 +32,18 @@ export function useManagers() {
   const addMgr = useMutation(
     ({ manager }) => addManager([{ mgrname: manager }]),
     {
-      onSuccess: () => invalidateManagerQueries,
+      onSuccess: invalidateManagerQueries,
     }
   );
 
   const delMgr = useMutation(
     ({ id, manager }) => deleteManger([{ id, mgrname: manager }]),
     {
-      onSuccess: () => invalidateManagerQueries,
+      onSuccess: invalidateManagerQueries,
     }
   );
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    addMgr.mutate({ manager });
-    setManager("");
-  };
-
-  const handleChange = (e) => {
-    setManager(e.target.value);
-  };
-
-  const handleDelete = (id, mgrname) => {
-    delMgr.mutate({ id, mgrname });
-  };
-
-  return { managersQuery, manager, handleChange, handleSubmit, handleDelete };
+  return { managersQuery, addMgr, delMgr };
 }
 
 export function useAccounts() {

--- a/src/pages/EditManagers.jsx
+++ b/src/pages/EditManagers.jsx
@@ -2,19 +2,33 @@ import styles from "./EditManagers.module.css";
 import { PiTrashBold } from "react-icons/pi";
 import { RiArrowGoBackFill } from "react-icons/ri";
 import { AiOutlineEnter } from "react-icons/ai";
-import { useManagers } from "../hooks/useManagers";
 import { useGoHome } from "../hooks/useNavigator";
+import { useState } from "react";
+import { useEditManagers } from "../hooks/Admins";
 
 export default function EditManagers() {
-  const { handleClick } = useGoHome();
+  const [manager, setManager] = useState("");
 
+  const { handleClick } = useGoHome();
   const {
     managersQuery: { isLoading, error, data: initialManagers },
-    manager,
-    handleChange,
-    handleSubmit,
-    handleDelete,
-  } = useManagers();
+    addMgr,
+    delMgr,
+  } = useEditManagers();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    addMgr.mutate({ manager });
+    setManager("");
+  };
+
+  const handleChange = (e) => {
+    setManager(e.target.value);
+  };
+
+  const handleDelete = (id, mgrname) => {
+    delMgr.mutate({ id, mgrname });
+  };
 
   return (
     <>
@@ -31,25 +45,24 @@ export default function EditManagers() {
           </div>
 
           <ul className={styles.box}>
-            {initialManagers &&
-              initialManagers.map(({ id, mgrname }) => (
-                <li className={styles.card} key={id}>
-                  <span className={styles.card__name}>{mgrname}</span>
-                  <button
-                    onClick={() => {
-                      handleDelete(id, mgrname);
-                    }}
-                    className={styles.cover}
-                  >
-                    <PiTrashBold />
-                  </button>
-                </li>
-              ))}
+            {initialManagers.map(({ id, mgrname }) => (
+              <li className={styles.card} key={id}>
+                <span className={styles.card__name}>{mgrname}</span>
+                <button
+                  onClick={() => {
+                    handleDelete(id, mgrname);
+                  }}
+                  className={styles.cover}
+                >
+                  <PiTrashBold />
+                </button>
+              </li>
+            ))}
           </ul>
           <form className={styles.form} onSubmit={handleSubmit}>
             <input
               className={styles.input}
-              type='text'
+              type="text"
               value={manager}
               onChange={handleChange}
             />


### PR DESCRIPTION
## 작업 내용
1. addMgr, delMgr의 mutation의 onSuccess 내부에서 중복 사용되던 invalidateQueries를 함수화한 후에 캐시 무효화에 사용되는 캐시 키를 배열로 선언해 사용
2. EditManagers에서 사용하는 useManagers 커스텀 훅의 이름을 useEditMangers로 변경
3. 코드의 가독성을 위해 커스텀 훅 내부의 핸들러 함수를 컴포넌트로 이동